### PR TITLE
to_cells: include fully contained polygons with ContainmentMode::IntersectsBoundary

### DIFF
--- a/tests/api/geom/to_cells.rs
+++ b/tests/api/geom/to_cells.rs
@@ -1,5 +1,6 @@
 use ahash::HashSet;
 use geo::{coord, polygon, LineString};
+use h3o::geom::ContainmentMode;
 use h3o::{
     geom::{PolyfillConfig, Polygon, ToCells},
     CellIndex, LatLng, Resolution,
@@ -366,4 +367,38 @@ fn pentagon_shape() -> geo::Polygon<f64> {
         (x: coord.x + edge_length_2, y: coord.y - edge_length_2),
         (x: coord.x - edge_length_2, y: coord.y - edge_length_2)
     ]
+}
+
+#[test]
+fn fully_in_cell_contained_geometry() {
+    // Build a geometry that is fully contained in the target cell.
+    // The geometry does not touch the cells boundary
+    let ll = LatLng::from_radians(1., 2.).expect("ll");
+    let cell = ll.to_cell(Resolution::One);
+    let cell_ring: Vec<_> = cell
+        .center_child(Resolution::Four)
+        .expect("center_child")
+        .grid_disk_distances(2);
+    let coord_ring = cell_ring
+        .iter()
+        .filter(|(_, k)| *k == 2)
+        .next()
+        .expect("first k=2 of ring")
+        .0
+        .boundary()
+        .iter()
+        .copied()
+        .map(|ll| coord! {x: ll.lng_radians(), y:ll.lat_radians()})
+        .collect();
+    let shape = geo::Polygon::new(coord_ring, Vec::new());
+
+    // to cells
+    let polygon = Polygon::from_radians(shape).expect("polygon");
+    let config = PolyfillConfig::new(cell.resolution())
+        .containment_mode(ContainmentMode::IntersectsBoundary);
+    let count = polygon.max_cells_count(config);
+    let result = polygon.to_cells(config).count();
+
+    assert_eq!(count, 18);
+    assert_eq!(result, 1);
 }


### PR DESCRIPTION
Hi,

when converting a geometry which is fully contained in the target cell to H3, that cell is not found, even when using IntersectionMode::IntersectsBoundary. It would be a valid usecase to have a IntersectionMode to handle such situations and IntersectsBoundary is already intended for partial intersection, although - when thinking about it again - its name is quite clear. Not if its worth to add one more mode for this or integrate it into boundary intersection mode.

We stumbled over this in https://github.com/nmandery/h3ronpy/issues/43, this behavior would certainly be useful for spatial analysis. 

This PR is mostly intended for demonstration. 