### PR TITLE
LatLng from NonNaNFinite<f64>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ std = ["dep:ahash"]
 geo = ["dep:geo", "dep:geojson"]
 serde = ["dep:serde", "dep:serde_repr"]
 tools = ["polyfit-rs"]
+typed_floats = ["dep:typed_floats"]
 
 [dependencies]
 ahash = { version = "0.8", optional = true, default-features = false, features = ["std", "compile-time-rng"] }
@@ -43,6 +44,7 @@ libm = { version = "0.2", default-features = false }
 polyfit-rs = { version = "0.2", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 serde_repr = { version = "0.1", optional = true, default-features = false }
+typed_floats = { version = "0.7", optional = true, default-features = false }
 
 [dev-dependencies]
 approx = { version = "0.5", default-features = false }

--- a/src/coord/latlng.rs
+++ b/src/coord/latlng.rs
@@ -443,6 +443,20 @@ impl From<LatLng> for geo::Coord {
     }
 }
 
+#[cfg(feature = "typed_floats")]
+mod typed_floats {
+    // Types for readability
+    type TFCoord = typed_floats::NonNaNFinite<f64>;
+    type TFLatlng = (TFCoord, TFCoord);
+
+    impl From<TFLatlng> for crate::LatLng {
+        fn from(latlng :TFLatlng) -> Self {
+            // SAFETY: `NonNaNFinite` guarantees that the values are finite.
+            Self::new_unchecked(latlng.0.into(), latlng.1.into())
+        }
+    }
+}
+
 #[cfg(feature = "geo")]
 impl TryFrom<geo::Coord> for LatLng {
     type Error = InvalidLatLng;

--- a/tests/api/latlng.rs
+++ b/tests/api/latlng.rs
@@ -118,3 +118,12 @@ fn latlng_from_geo_coord() {
 
     assert_eq!(result, expected);
 }
+
+#[cfg(feature = "typed_floats")]
+#[test]
+fn latlng_from_typed_floats() {
+    let lat = typed_floats::NonNaNFinite::<f64>::new(48.864716).unwrap();
+    let lng = typed_floats::NonNaNFinite::<f64>::new(2.349014).unwrap();
+
+    let _ = LatLng::from((lat, lng));
+}


### PR DESCRIPTION
It allows to generate a `LatLng` from a `f64` that is already ensured to be finite.
