### PR TITLE
remove konst dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ typed_floats = ["dep:typed_floats"]
 [dependencies]
 ahash = { version = "0.8", optional = true, default-features = false, features = ["std", "compile-time-rng"] }
 arbitrary = { version = "1.0", optional = true, default-features = false }
-konst = { version = "0.3", default-features = false, features = ["parsing"] }
 either = { version = "1.0", default-features = false }
 float_eq = { version = "1.0", default-features = false }
 geo = { version = "0.27", optional = true, default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,8 +248,6 @@
 
 extern crate alloc;
 
-use konst::{primitive::parse_u8 as as_u8, result::unwrap_ctx as unwrap};
-
 mod base_cell;
 mod boundary;
 mod coord;
@@ -282,13 +280,6 @@ pub use resolution::Resolution;
 use resolution::ExtendedResolution;
 
 // -----------------------------------------------------------------------------
-
-/// H3O major version number.
-pub const VERSION_MAJOR: u8 = unwrap!(as_u8(env!("CARGO_PKG_VERSION_MAJOR")));
-/// H3O minor version number.
-pub const VERSION_MINOR: u8 = unwrap!(as_u8(env!("CARGO_PKG_VERSION_MINOR")));
-/// H3O patch version number.
-pub const VERSION_PATCH: u8 = unwrap!(as_u8(env!("CARGO_PKG_VERSION_PATCH")));
 
 /// An icosahedron has 20 faces.
 const NUM_ICOSA_FACES: usize = 20;


### PR DESCRIPTION
For obscure reasons, konst and its dependency const_panic seems to produce references to non aligned pointers to debug strings in the __DATA_CONST segment on MachO...

Which result in a linking error with ld64 only on macOS (works fine in lld):

ld: warning: pointer not aligned at l_anon.048eb5c2bcd732de0d26803c8ad2aab0.28+0x1 (konst-1160989638.konst.107d0808121abeeb-cgu.0.rcgu.o)
ld: warning: pointer not aligned at l_anon.2c21d6ae135169ab639cabf1d12eea7d.91+0x1 (const_panic-1924350486.const_panic.41c40ef33595b1d4-cgu.0.rcgu.o)

I see the misaligned symbols when disassembling the corresponding .o file but I couldn't find what exactly causes it...
![image](https://github.com/HydroniumLabs/h3o/assets/1126594/2641f8ab-6163-413d-af28-db29823605c9)

This PR removes konst and therefore const_panic which produces .o that can be linked with ld64.
Their only usage was for setting const values that weren't even used, and also not sure how they could have been set at all ?