### PR TITLE
Share boundary calculation in `intersects_or_contains`

### DIFF
--- a/src/geom/geometry/polygon.rs
+++ b/src/geom/geometry/polygon.rs
@@ -390,24 +390,24 @@ fn intersects_or_contains(polygon: &Polygon, cell: CellIndex) -> bool {
 fn intersects_boundary(polygon: &Polygon, boundary: &Ring) -> bool {
     let intersects_envelope = polygon
         .exterior
-        .intersects_boundary(Cow::Borrowed(&boundary));
+        .intersects_boundary(Cow::Borrowed(boundary));
 
     intersects_envelope || {
         polygon
             .interiors
             .iter()
-            .any(|ring| ring.intersects_boundary(Cow::Borrowed(&boundary)))
+            .any(|ring| ring.intersects_boundary(Cow::Borrowed(boundary)))
     }
 }
 
 fn contains_boundary(polygon: &Polygon, boundary: &Ring) -> bool {
     let within_envelope =
-        polygon.exterior.contains_boundary(Cow::Borrowed(&boundary));
+        polygon.exterior.contains_boundary(Cow::Borrowed(boundary));
 
     within_envelope
         && !polygon.interiors.iter().any(|ring| {
-            ring.intersects_boundary(Cow::Borrowed(&boundary))
-                || ring.contains_boundary(Cow::Borrowed(&boundary))
+            ring.intersects_boundary(Cow::Borrowed(boundary))
+                || ring.contains_boundary(Cow::Borrowed(boundary))
         })
 }
 


### PR DESCRIPTION
`intersects_or_contains` may call `intersects_boundary` and `contains_boundary` for a cell. Both of these functions internally call an expensive function `compute_cell_ring`, even though it's the same for the cell being tested by `intersects_or_contains`.

Instead we could call `compute_cell_ring` inside of `intersects_or_contains` to share it between `intersects_boundary` and `contains_boundary`.