### PR TITLE
Bump `geo` to 0.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Possible sections are:
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- bump `geo` to 0.33
+
 ## [0.9.4] - 2025-12-05
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "h3o"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Sylvain Laperche <sylvain.laperche@gmail.com>"]
 edition = "2024"
 description = "A Rust implementation of the H3 geospatial indexing system."
@@ -36,7 +36,7 @@ ahash = { version = "0.8", optional = true, default-features = false, features =
 arbitrary = { version = "1.0", optional = true, default-features = false }
 either = { version = "1.0", default-features = false }
 float_eq = { version = "1.0", default-features = false }
-geo = { version = "0.32", optional = true, default-features = false }
+geo = { version = "0.33", optional = true, default-features = false }
 h3o-bit = { version = "0.1", default-features = false }
 libm = { version = "0.2", default-features = false }
 polyfit-rs = { version = "0.2", optional = true, default-features = false }


### PR DESCRIPTION
This PR updates the optional `geo` dependency to v0.33.

I wasn't sure if I should update the `h3o` package version in Cargo.toml or not, so I just mimicked what's been done in recent "bump" commits. Let me know if I should undo that change 🙂 