### PR TITLE
feat: add PolygonTrait for boundary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ arbitrary = { version = "1.0", optional = true, default-features = false }
 either = { version = "1.0", default-features = false }
 float_eq = { version = "1.0", default-features = false }
 geo = { version = "0.33", optional = true, default-features = false }
-geo-traits = { version = "0.3", optional = true, default-features = false }
+geo-traits = { version = "0.3", optional = true, default-features = false, features = ["geo-types"] }
 h3o-bit = { version = "0.1", default-features = false }
 libm = { version = "0.2", default-features = false }
 polyfit-rs = { version = "0.2", optional = true, default-features = false }

--- a/src/boundary.rs
+++ b/src/boundary.rs
@@ -91,7 +91,7 @@ impl geo_traits::GeometryTrait for Boundary {
     where
         Self: 'b;
     type PolygonType<'b>
-        = geo_traits::UnimplementedPolygon<f64>
+        = Self
     where
         Self: 'b;
     type RectType<'b>
@@ -123,7 +123,11 @@ impl geo_traits::GeometryTrait for Boundary {
         Self::TriangleType<'_>,
         Self::LineType<'_>,
     > {
-        geo_traits::GeometryType::LineString(self)
+        if self.count >= crate::NUM_PENT_VERTS {
+            geo_traits::GeometryType::Polygon(self)
+        } else {
+            geo_traits::GeometryType::LineString(self)
+        }
     }
 }
 
@@ -144,5 +148,42 @@ impl geo_traits::LineStringTrait for Boundary {
     unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_> {
         // SAFETY: precondition must be held by the caller.
         unsafe { *self.get_unchecked(i) }
+    }
+}
+
+#[cfg(feature = "geo")]
+impl geo_traits::PolygonTrait for Boundary {
+    type RingType<'a>
+        = geo::LineString
+    where
+        Self: 'a;
+
+    /// Returns the exsterior ring for pentagons and hexagons.
+    /// For edges, `None` is returned.
+    fn exterior(&self) -> Option<Self::RingType<'_>> {
+        if self.count >= crate::NUM_PENT_VERTS {
+            let mut coords = self
+                .iter()
+                .copied()
+                .map(geo::Coord::from)
+                .collect::<Vec<_>>();
+            coords.push(coords[0]);
+            Some(geo::LineString::new(coords))
+        } else {
+            None
+        }
+    }
+
+    /// H3 cell have no interrior rings.
+    fn num_interiors(&self) -> usize {
+        0
+    }
+
+    /// # Safety
+    ///
+    /// Accessing an index out of bounds is UB.
+    #[expect(unsafe_code, reason = "precondition must be held by the caller")]
+    unsafe fn interior_unchecked(&self, _i: usize) -> Self::RingType<'_> {
+        unreachable!("Boundary has no interior rings")
     }
 }


### PR DESCRIPTION
I'm wondering if you would be comfortable with something like this as a way to implement PolygonTrait _as well as_ the `LineStringTrait` for `Boundary`.

The key quote im leaning on from the docs is: 

> "Coordinate access is expected to be constant-time but not necessarily free."

The key challenge is that the Polygon exterior ring needs to have a closed vertex which, as i understand, the boundary _does not_ do this. So setting `RingType<'a> = Boundary` doesn't suffice.

Here, we can take the boundary, ensure it is 5+ coords (pentagon or hexagon), then copy the first coord into the last position and construct a `LineString` which _does_ have the `LineStringTrait` implemented for it. 

What do you think? Otherwise, it is indeed fine, and we can use the `geo` feature of `h3o` and rely on the `geo-traits` support of `geo-types` for constructing a polygon from the CellIndex